### PR TITLE
Render Hash :id via configurable PubId class

### DIFF
--- a/_plugins/jekyll-index.rb
+++ b/_plugins/jekyll-index.rb
@@ -46,12 +46,35 @@ module JekyllIndex
     end
 
     def reference(item, hash)
+      rendered = render_id(item[:id])
       if @site.config['jekyll-index']['add_type_to_reference']
         type = hash['docid'].find { |id| id['primary'] }['type']
-        "#{type} #{item[:id]}"
+        "#{type} #{rendered}"
       else
-        item[:id]
+        rendered
       end
+    end
+
+    # Render the index :id field. `Relaton::Index` stores it as a Hash for
+    # flavors that key the index by parts (e.g. relaton-w3c). To turn that
+    # back into a printable identifier we instantiate a flavor-supplied
+    # PubId class and call `to_s`. Flavor selection comes from per-data-repo
+    # config, so this plugin stays generic.
+    def render_id(id)
+      return id if id.is_a?(String)
+      return id.to_s unless id.is_a?(Hash)
+
+      klass = pubid_class
+      klass ? klass.new(**id).to_s : id.to_s
+    end
+
+    def pubid_class
+      return @pubid_class if defined?(@pubid_class)
+
+      config = @site.config['jekyll-index']
+      require config['pubid_require'] if config['pubid_require']
+      name = config['pubid_class']
+      @pubid_class = name ? Object.const_get(name) : nil
     end
 
     def collection


### PR DESCRIPTION
## Summary

The plugin's `reference()` does `"#{type} #{item[:id]}"`, but `Relaton::Index` stores `:id` as a Hash for flavors that key by parts (e.g. relaton-w3c calls `add_or_update(pubid.to_hash, file)`). Ruby string-interpolates the hash, so the live https://relaton.github.io/relaton-data-w3c/ renders `<h4>W3C {:code=>"vibration", :stage=>"CRD", :date=>"20260502"}</h4>` instead of `W3C CRD-vibration-20260502`.

This PR makes `render_id` dispatch on the type of `:id`:

- `String` → use as-is (no behavior change).
- `Hash` → require the configured `pubid_require` path, look up `pubid_class` from `_config.yml`, instantiate with `**id`, and call `to_s`.
- anything else → fall back to `to_s` (same as today).

Two new optional `jekyll-index` config keys, both off by default — sibling data repos that don't opt in keep current behavior:

```yaml
jekyll-index:
  pubid_class: 'Relaton::W3c::PubId'
  pubid_require: 'relaton/w3c/pubid'
```

The plugin stays generic — **no static dependency on any flavor gem**, the require is dynamic and gated by config.

## Rollout (downstream, not in this PR)

1. Cut a relaton-w3c release that includes `Relaton::W3c::PubId#to_s` (added separately on the relaton-w3c side).
2. Bump `relaton-data-w3c/Gemfile` constraint if needed.
3. Add `pubid_class`/`pubid_require` to `relaton-data-w3c/_config.yml` on `main` (and `v2`).
4. Re-run Deploy on `main`.

## Test plan

- [ ] Manual smoke: with `pubid_class: 'Relaton::W3c::PubId'` in `_config.yml`, build relaton-data-w3c locally and confirm the `<h4>` reads `W3C CRD-vibration-20260502`.
- [ ] Without the new config keys, build any sibling data repo (e.g. relaton-data-iso) and confirm no behavior change vs. main.