### PR TITLE
Accept relaton-bib 2.x YAML field names

### DIFF
--- a/_plugins/jekyll-index.rb
+++ b/_plugins/jekyll-index.rb
@@ -33,23 +33,38 @@ module JekyllIndex
 
     def data(item, hash)
       date = date(hash)
-      stage = hash.dig('docstatus', 'stage', 'value') || date['type']
+      stage = hash.dig('docstatus', 'stage', 'value') || (date && date['type'])
       yaml_ref = "#{@site.config['jekyll-index']['baseurl']}#{item[:file]}"
       {
-        'ref' => reference(item, hash), 'doctype' => hash['doctype'], 'stage' => stage, 'date' => date['value'],
-        'yaml_ref' => yaml_ref
+        'ref' => reference(item, hash), 'doctype' => hash['doctype'], 'stage' => stage,
+        'date' => date_value(date), 'yaml_ref' => yaml_ref
       }
     end
 
+    # `relaton-bib` >= 2.x writes `at`; legacy data files use `value`.
+    def date_value(date)
+      date && (date['value'] || date['at'])
+    end
+
     def date(hash)
-      hash['date'].find { |d| d['type'] == 'published' } || hash['date'].first
+      dates = hash['date'] || []
+      dates.find { |d| d['type'] == 'published' } || dates.first
+    end
+
+    # Primary docidentifier. `relaton-bib` >= 2.x serializes as
+    # `docidentifier` with a `content` field; legacy data files use
+    # `docid` with an `id` field. Accept both.
+    def primary_docid(hash)
+      list = hash['docidentifier'] || hash['docid'] || []
+      list.find { |d| d['primary'] }
     end
 
     def reference(item, hash)
       rendered = render_id(item[:id])
       if @site.config['jekyll-index']['add_type_to_reference']
-        type = hash['docid'].find { |id| id['primary'] }['type']
-        "#{type} #{rendered}"
+        primary = primary_docid(hash)
+        type = primary && primary['type']
+        type ? "#{type} #{rendered}" : rendered
       else
         rendered
       end


### PR DESCRIPTION
## Summary

Follow-up to #3. After the lutaml-based DataFetcher rewrite in `relaton-w3c` (and analogous changes in other relaton-bib 2.x flavors), data YAML files have **renamed fields** that this plugin doesn't know about:

| Plugin reads | New (relaton-bib 2.x) | Effect today |
|---|---|---|
| `hash['docid']` | `hash['docidentifier']` | `nil` → `.find` raises → `create_doc` rescues → doc skipped |
| `docid[primary]['id']` | `docidentifier[primary]['content']` | rendered string lives in a different key |
| `date[published]['value']` | `date[published]['at']` | published date renders blank |

Symptom: in [relaton-data-w3c@v2 build 25413343689](https://github.com/relaton/relaton-data-w3c/actions/runs/25413343689), every data file logs `Error during processing data/<x>.yaml, skipped. undefined method 'find' for nil:NilClass`. The built `index.html` is empty (no `<h4 class=\"reference\">` anywhere).

This PR makes the plugin accept **both shapes** (it falls back from the new field name to the legacy one), so:
- Sibling repos still on the legacy shape are unaffected.
- Repos that have moved to relaton-bib 2.x output build green.

While in here, hardened a couple of nil paths so a single malformed entry warns and skips instead of crashing the whole build.

## Test plan

- [ ] Build [relaton-data-w3c@v2](https://github.com/relaton/relaton-data-w3c/tree/v2) (uses new shape) → expect populated `index.html` with proper `<h4 class=\"reference\">W3C …</h4>` headings, no warnings.
- [ ] Build any sibling repo still on legacy shape → expect identical output to today's `main`.