### PR TITLE
Truncate index pagination with windowed page numbers

### DIFF
--- a/_includes/pager.html
+++ b/_includes/pager.html
@@ -1,3 +1,11 @@
+{% assign window = 3 %}
+{% assign current = paginator.page %}
+{% assign total = paginator.total_pages %}
+
+{% assign window_start = current | minus: window %}
+{% if window_start < 1 %}{% assign window_start = 1 %}{% endif %}
+{% assign window_end = current | plus: window %}
+{% if window_end > total %}{% assign window_end = total %}{% endif %}
 
 <div class="center-align">
   <ul class="pagination">
@@ -14,8 +22,19 @@
       </a>
     </li>
 
-    {% for page in (1..paginator.total_pages) %}
-      {% if page == paginator.page %}
+    {% if window_start > 1 %}
+      {% if current == 1 %}
+        <li class="active"><a href="#!">1</a></li>
+      {% else %}
+        <li class="waves-effect"><a href="{{ '/' | relative_url }}">1</a></li>
+      {% endif %}
+      {% if window_start > 2 %}
+        <li class="disabled"><a href="#!">&hellip;</a></li>
+      {% endif %}
+    {% endif %}
+
+    {% for page in (window_start..window_end) %}
+      {% if page == current %}
         {% assign page_class = 'active' %}
         {% assign page_url = '#!' %}
       {% elsif page == 1 %}
@@ -29,6 +48,15 @@
         <a href="{{ page_url }}">{{ page }}</a>
       </li>
     {% endfor %}
+
+    {% assign last_minus_one = total | minus: 1 %}
+    {% if window_end < total %}
+      {% if window_end < last_minus_one %}
+        <li class="disabled"><a href="#!">&hellip;</a></li>
+      {% endif %}
+      {% assign last_url = site.paginate_path | relative_url | replace: ':num', total %}
+      <li class="waves-effect"><a href="{{ last_url }}">{{ total }}</a></li>
+    {% endif %}
 
     {% if paginator.next_page %}
       {% assign next_class = 'waves-effect' %}


### PR DESCRIPTION
## Summary
- Replace the all-pages `for` loop in `_includes/pager.html` with a windowed renderer (first page, last page, current ± 3, `…` for gaps).
- Indexes with thousands of pages currently emit one `<li>` per page on every page of the site, producing unusable pagers and inflating every generated HTML file by megabytes.

### Behavior (window = 3)

| total | current | output |
| ----- | ------- | ------ |
| 1170  | 1       | `< 1 2 3 4 … 1170 >` |
| 1170  | 5       | `< 1 2 3 4 5 6 7 8 … 1170 >` |
| 1170  | 1170    | `< 1 … 1167 1168 1169 1170 >` |
| 5     | 3       | `< 1 2 3 4 5 >` (no `…`, no duplicates) |
| 1     | 1       | `< 1 >` |

The leading/trailing first-and-last blocks are guarded so they never duplicate a page already inside the window, and the `…` is suppressed when the window is adjacent to page 1 or the last page.

## Test plan
- [ ] Build a large `relaton-data-*` repo locally with this branch checked out into `src/` (matching the steps in `support/.github/workflows/data-deploy.yml`); confirm the rendered pager on first / middle / last pages.
- [ ] Compare `_site/index.html` size before vs. after on a 1000+-page index — expect a multi-MB drop.
- [ ] Build a small index (or temporarily raise `paginate`) and confirm `< 1 >` renders without stray `…` or duplicate `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)