### PR TITLE
Make the search filter feel responsive while the index downloads

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,6 +12,7 @@
     <script src="{{ "/assets/js/materialize.min.js" | relative_url }}"></script>
     <script src="{{ "/assets/js/copy.js" | relative_url }}"></script>
     <script src="{{ "/assets/js/search.js" | relative_url }}"></script>
+    <link rel="prefetch" href="{{ '/search.json' | relative_url }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}" />
 <!-- Not needed with our site
     <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}" />

--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -275,7 +275,8 @@ main {
   margin: 1rem 0;
 }
 
-.search-empty {
+.search-empty,
+.search-loading {
   padding: 1rem;
   color: #757575;
   font-size: 0.95em;
@@ -284,5 +285,22 @@ main {
   border: 1px dashed #e0e0e0;
   border-radius: 2px;
   margin: 1rem 0;
+}
+
+.search-loading::before {
+  content: "";
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  margin-right: 0.5rem;
+  vertical-align: middle;
+  border: 2px solid #ccc;
+  border-top-color: #7e57c2;
+  border-radius: 50%;
+  animation: search-spin 0.8s linear infinite;
+}
+
+@keyframes search-spin {
+  to { transform: rotate(360deg); }
 }
 

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -154,6 +154,14 @@ document.addEventListener('DOMContentLoaded', () => {
     status.innerHTML = '';
   };
 
+  const showLoading = () => {
+    defaultArea.hidden = true;
+    filteredArea.innerHTML = '';
+    filteredArea.hidden = true;
+    status.hidden = false;
+    status.innerHTML = '<div class="search-loading">Loading search index&hellip;</div>';
+  };
+
   const showError = (message) => {
     defaultArea.hidden = true;
     filteredArea.innerHTML = '';
@@ -172,6 +180,8 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
+    if (!index) showLoading();
+
     let data;
     try {
       data = await loadIndex();
@@ -181,11 +191,17 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    currentQuery = query;
+    const liveQuery = input.value.trim().toLowerCase();
+    if (!liveQuery) {
+      showDefault();
+      return;
+    }
+
+    currentQuery = liveQuery;
     matches = [];
     for (let i = 0; i < data.length; i++) {
       const ref = data[i].r;
-      if (ref && ref.toLowerCase().indexOf(query) !== -1) matches.push(data[i]);
+      if (ref && ref.toLowerCase().indexOf(liveQuery) !== -1) matches.push(data[i]);
     }
     currentPage = 1;
     renderResults();


### PR DESCRIPTION
## Summary
Reported on the live \`relaton-data-w3c\` site as \"the filter doesn't work.\" In headless Chromium / Firefox / WebKit the filter does work — the issue was that the ~2.8 MB \`search.json\` is fetched lazily on the first interaction, so users typing on a slow / cold cache see no change for several seconds and assume nothing is happening.

Two complementary fixes:

1. **\`<link rel=\"prefetch\">\` for \`/search.json\`** in \`_includes/head.html\`. Browsers pull the JSON in idle time after the main page renders, so by the time the user clicks the filter the JSON is usually already in the HTTP cache.

2. **Loading indicator** in \`assets/js/search.js\`. If the user types before the index has loaded, hide the static list and show a \"Loading search index…\" spinner in the status banner. The filter re-checks the input value when the fetch resolves so the loading state transitions seamlessly into results.

Also adds a small CSS spinner for the loading state in \`_sass/style.scss\`.

## Test plan
- [ ] Hard-refresh a large data site with DevTools network throttling (e.g. \"Slow 3G\"), type immediately, and confirm the loading spinner appears and is replaced by results once the JSON arrives.
- [ ] On a normal connection, confirm the filter responds instantly because the prefetch link populated the cache before the user interacted.
- [ ] With JS disabled, confirm the page still renders normally (the prefetch link is harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)